### PR TITLE
Adding support to send a CardId as a Method

### DIFF
--- a/src/chargeIO.Test/TransactionServiceTest.cs
+++ b/src/chargeIO.Test/TransactionServiceTest.cs
@@ -69,6 +69,37 @@ namespace ChargeIO.Test
         }
 
         [Test]
+        public void TestChargeWithCardId()
+        {
+            Card card = paymentMethodService.CreateCard(new CardOptions()
+            {
+                Number = "5105105105105100",
+                Cvv = "123",
+                ExpMonth = 12,
+                ExpYear = 2016,
+                Name = "John Doe",
+                Email = "jdoe@example.com",
+                Phone = "111-222-3344",
+                Description = "Company Card",
+                Reference = "Customerjdoe123"
+            });
+
+
+            Charge charge = transactionService.Charge(new ChargeOptions()
+            {
+                AmountInCents = 345,
+                Method = new CardReferenceOptions()
+                {
+                    CardId = card.Id
+                }
+            });
+
+            Assert.AreEqual("AUTHORIZED", charge.Status);
+            Assert.NotNull(charge.Id);
+            Assert.IsTrue(charge.AmountInCents == 345);
+        }
+
+        [Test]
         public void TestRefund()
         {
             Charge charge = transactionService.Charge(new ChargeOptions()

--- a/src/chargeIO/Infrastructure/Mapper.cs
+++ b/src/chargeIO/Infrastructure/Mapper.cs
@@ -118,6 +118,28 @@ namespace ChargeIO
         }
     }
 
+    public class CardReferenceConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            CardReferenceOptions options = (CardReferenceOptions)value;
+            writer.WriteValue(options.CardId);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            CardReferenceOptions options = new CardReferenceOptions();
+            options.CardId = (string)reader.Value;
+            return options;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(CardReferenceOptions);
+        }
+    }
+
+
     public class IsoDateConverter : Newtonsoft.Json.Converters.IsoDateTimeConverter
     {
         public IsoDateConverter()

--- a/src/chargeIO/Services/PaymentMethods/CardReferenceOptions.cs
+++ b/src/chargeIO/Services/PaymentMethods/CardReferenceOptions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace ChargeIO
+{
+    [JsonConverter(typeof(CardReferenceConverter))]
+    public class CardReferenceOptions : IPaymentMethod
+    {
+        public string CardId { get; set; }
+    }
+}

--- a/src/chargeIO/chargeIO.csproj
+++ b/src/chargeIO/chargeIO.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Infrastructure\Urls.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\PaymentMethods\BankOptions.cs" />
+    <Compile Include="Services\PaymentMethods\CardReferenceOptions.cs" />
     <Compile Include="Services\PaymentMethods\TokenReferenceOptions.cs" />
     <Compile Include="Services\RecurringCharges\RecurringChargeOptions.cs" />
     <Compile Include="Services\RecurringCharges\RecurringChargeService.cs" />


### PR DESCRIPTION
Currently on my company, we are attempting to perform a `Charge` sending an stored Credit Card `Id` as a `Method` (similar to using the `TokenId` as a `Method`). I didn't see any support for this on the library, so I did this code modification in order to add some support for that. It uses a very similar logic from the `TokenReferenceOptions` class, you will now see a `CardReferenceOptions` class. Unit test passed.
