### PR TITLE
Configuration updates for optional app settings

### DIFF
--- a/chargeio/appsettings.json
+++ b/chargeio/appsettings.json
@@ -1,5 +1,5 @@
 {
     "ChargeIOSecretKey": "<Your OAuth Secret>",
     "ChargeIOApiUrl": "https://api.chargeio.com/v1",
-    "ChargeIOHTTPTimeout": "20000"
+    "ChargeIOHTTPTimeout": "30000"
 }

--- a/chargeio/infrastructure/Configuration.cs
+++ b/chargeio/infrastructure/Configuration.cs
@@ -6,7 +6,7 @@ namespace ChargeIO.Infrastructure
 {
 	public static class Configuration
 	{
-        public static IConfigurationRoot Get { get; }
+        public static IConfigurationRoot AppCfg { get; }
 		public static string SecretKey { get; }
 		public static string ApiUrl { get; }
 		public static long HttpTimeout { get; }
@@ -14,14 +14,19 @@ namespace ChargeIO.Infrastructure
 
         static Configuration()
         {
-            var configuration = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json", false, true)
+            var builder = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", true, true)
                 .AddEnvironmentVariables();
 
-            Get = configuration.Build();
-            SecretKey = Get["ChargeIOSecretKey"];
-            ApiUrl = Get["ChargeIOApiUrl"];
-            HttpTimeout = long.Parse(Get["ChargeIOHTTPTimeout"]);
+            AppCfg = builder.Build();
+            SecretKey = AppCfg["ChargeIOSecretKey"];
+
+            string apiUrl = AppCfg["ChargeIOApiUrl"];
+            ApiUrl = apiUrl != null ? apiUrl : "https://api.chargeio.com/v1";
+
+            long timeout = long.TryParse(AppCfg["ChargeIOHTTPTimeout"], out timeout) ? timeout : 30000;
+            HttpTimeout = timeout;
+
 	        AssemblyVersion = typeof(Configuration).GetTypeInfo().Assembly.GetName().Version;
         }
 	}


### PR DESCRIPTION
Make load of configuration file appsettings.json optional, provide sensible defaults for API URL and HTTP timeout when configuration is not present.